### PR TITLE
Disable comment char # when reading mzTab. Closes #21

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rmzTabM
 Title: R Package Client for mzTab-M Reference Implementation and Validation API
-Version: 1.0.5.9001
+Version: 1.0.5.9002
 Authors@R: c(
     person("Nils", "Hoffmann", email = "nils.hoffmann@cebitec.uni-bielefeld.de", role=c("aut","cre"), comment = c(ORCID = "0000-0002-6540-6875")),
     person("Steffen", "Neumann", email = "sneumann@ipb-halle.de", role=c("aut"), comment = c(ORCID = "0000-0002-7899-7192")))

--- a/R/read_mz_tab.R
+++ b/R/read_mz_tab.R
@@ -9,7 +9,8 @@ readMzTab <- function(filename) {
   mztab.table = utils::read.table(file=filename, header=FALSE,
                     row.names=NULL, dec = ".", fill = TRUE,
                     col.names = paste0("V", seq_len(ncol)),
-                    sep="\t", na.strings="null", quote = "", colClasses = "character")
+                    sep="\t", na.strings="null", quote = "", comment.char = "",
+                    colClasses = "character")
   mztab.table
 }
 
@@ -28,7 +29,8 @@ readMzTabString <- function(mzTabString) {
   mztab.table = utils::read.table(file=file, header=FALSE,
                                   row.names=NULL, dec = ".", fill = TRUE,
                                   col.names = paste0("V", seq_len(ncol)),
-                                  sep="\t", na.strings="null", quote = "", colClasses = "character")
+                                  sep="\t", na.strings="null", quote = "", comment.char = "#",
+                                  colClasses = "character")
   mztab.table
 }
 


### PR DESCRIPTION
Checked and fixes my example here locally. 
I did NOT check if the mzTab-M specs somewhere define/allow # as comment char. 
In that case, the fix would be a tad more complex ...
Yours, Steffen