### PR TITLE
removed tidyr dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,7 +21,7 @@ Suggests:
     rmarkdown,
     kableExtra,
     stringi
-Imports: jsonlite, httr, R6, caTools, dplyr, tidyr, metabolighteR
+Imports: jsonlite, httr, R6, caTools, dplyr, metabolighteR
 Remotes:
     github::sneumann/metabolighteR@devel
 RoxygenNote: 7.2.0

--- a/R/read_mz_tab.R
+++ b/R/read_mz_tab.R
@@ -64,6 +64,12 @@ extractIds <- function(mtd.sub.table, column, regexp=idRegexp) {
   })
 }
 
+idElementsReshape <- function(x) {
+  tx <- t(x[[-1]])
+  colnames(tx) <- x[, 1]
+  data.frame(tx, check.names = FALSE)
+}
+
 extractId <- function(idElement, regexp=idRegexp) {
   as.numeric(gsub(idElementRegexp, "\\1", as.character(idElement)))
 }
@@ -94,7 +100,7 @@ extractIdElements <- function(mtd.sub.table, typePrefix, mapEmptyKeyTo="name") {
       warning(paste("Unsupported mapEmptyKeyTo property:", mapEmptyKeyTo, "Supported are 'name', 'param' and 'parameter'"))
     }
     # pivot table from long to wide format (which is the one JSONLITE expects)
-    subsetWide <- tidyr::pivot_wider(subset, names_from="V2", values_from="V3")
+    subsetWide <- idElementsReshape(subset)
     # add id as column
     subsetWide$id <- as.numeric(x)
     subsetWide


### PR DESCRIPTION
I have introduced a novel function, idElementsReshape, to replace tidyr::pivot_wider as it is used in rmzTabM. The only important thing about it is that it returns a data.frame with unchecked names (`r check.names = FALSE`) to mimic the column naming of tidyr::pivot_wider.

The only difference is that the object it returns does not have classess `tbl_df` or `tbl` which are tidyverse-specific and should not affect any functionalities in the package.

The package with idElementsReshape passes all the tests.
