### PR TITLE
Disable # comment parsing in mzTab-M readers

### DIFF
--- a/R/read_mz_tab.R
+++ b/R/read_mz_tab.R
@@ -12,7 +12,7 @@ readMzTab <- function(filename) {
   mztab.table = utils::read.table(file=filename, header=FALSE,
                     row.names=NULL, dec = ".", fill = TRUE,
                     col.names = paste0("V", seq_len(ncol)),
-                    sep="\t", na.strings="null", quote = "", comment.char = "#",
+                    sep="\t", na.strings="null", quote = "", comment.char = "",
                     blank.lines.skip = TRUE, strip.white = TRUE,
                     colClasses = "character")
   mztab.table
@@ -33,7 +33,7 @@ readMzTabString <- function(mzTabString) {
   mztab.table = utils::read.table(file=file, header=FALSE,
                                   row.names=NULL, dec = ".", fill = TRUE,
                                   col.names = paste0("V", seq_len(ncol)),
-                                  sep="\t", na.strings="null", quote = "", comment.char = "#",
+                                  sep="\t", na.strings="null", quote = "", comment.char = "",
                                   blank.lines.skip = TRUE, strip.white = TRUE,
                                   colClasses = "character")
   mztab.table


### PR DESCRIPTION
This PR sets `comment.char = ""` in both `readMzTab()` and `readMzTabString()`.

Fixes #40 